### PR TITLE
save diagnostic plots using obsid instead of stationname

### DIFF
--- a/bin/CAL_9_DIAGNOSTICS.py
+++ b/bin/CAL_9_DIAGNOSTICS.py
@@ -21,5 +21,5 @@ if __name__ == "__main__":
 
   for catchment_id in catchment_ids:
     obs_df, sim_df, stn_df, _ = construct_dfs(base_path, catchment_id, plot_groupings)
-    dis_fig = discharge_plot(obs_df, sim_df, stn_df, savepath)
-    other_figs = other_var_plots(sim_df, stn_df, plot_groupings, savepath)
+    dis_fig = discharge_plot(obs_df, sim_df, stn_df, catchment_id, savepath)
+    other_figs = other_var_plots(sim_df, stn_df, plot_groupings, catchment_id, savepath)

--- a/liscal/diagnostic_plots.py
+++ b/liscal/diagnostic_plots.py
@@ -33,7 +33,7 @@ def construct_dfs(base_path, catchment_id, plot_groupings):
   
   return observations_df, simulations_df, stations_info_df, stats_df # decide if we use stats_df or not
 
-def discharge_plot(observations_df, simulations_df, stations_info_df, savepath="", save=True):
+def discharge_plot(observations_df, simulations_df, stations_info_df, catchment_id, savepath="", save=True):
   fig = go.Figure()
   fig.add_trace(go.Scatter(
       x=simulations_df['time'],
@@ -57,10 +57,10 @@ def discharge_plot(observations_df, simulations_df, stations_info_df, savepath="
       height=500
   )
   if save:
-    fig.write_html(f"{savepath}{station_name}_dis.html")
+    fig.write_html(f"{savepath}{catchment_id}_dis.html")
   return fig
 
-def other_var_plots(simulations_df, stations_info_df, plot_groupings, savepath="", save=True):
+def other_var_plots(simulations_df, stations_info_df, plot_groupings, catchment_id, savepath="", save=True):
   figs = []
   for plot_vars in plot_groupings:
     num_plots = len(plot_vars)
@@ -88,6 +88,6 @@ def other_var_plots(simulations_df, stations_info_df, plot_groupings, savepath="
         for var in subplot_vars
     ]) + ".html"
     if save:
-      fig.write_html(f"{savepath}{station_name}_{figure_name}")
+      fig.write_html(f"{savepath}{catchment_id}_{figure_name}")
     figs.append(fig)
   return figs


### PR DESCRIPTION
Previously diagnostic plots were saved using the station name, which had some unintended problems since station names occasionally can include slashes. This PR updates to save using the obsid instead.