### PR TITLE
Feature/deapupdates

### DIFF
--- a/bin/CAL_2_HYDRO_DEPENDENCIES.py
+++ b/bin/CAL_2_HYDRO_DEPENDENCIES.py
@@ -234,7 +234,7 @@ if __name__=="__main__":
 						for line in f.readlines():
 							(X,Y,value) = line.split()
 							if float(value) > 1: # this means there is overlap, therefore move inlet further downstream
-								pcrasterCommand(pcrcalc + " 'F0 = upstream(F1,scalar(F2))*"+str(subcatchment)+"'", {"F0": tmp3_map, "F1":ldd_map, "F2":tmp2_map}) # move directly connected stations 1 pixel downstream
+								pcrasterCommand(pcrcalc + " 'F0 = upstream(F1,scalar(F2!=0))*"+str(subcatchment)+"'", {"F0": tmp3_map, "F1":ldd_map, "F2":tmp2_map}) # move directly connected stations 1 pixel downstream
 								pcrasterCommand(pcrcalc + " 'F0 = F1'", {"F0": tmp2_map, "F1":tmp3_map})
 						f.close()
 


### PR DESCRIPTION
I made a small correction for the multiple inflows at same grid point. The CAL_2 is checked and now the inflow.map has the correct IDs. I tested it on one of the affected catchments (4471_Ter) and I didn't get the previous warning. I only run the longetermrun when using all other data from the original calibration suite (efas6_full_calib). The generated timeseries are different from the original longetermrun, confirming that the previously-ommited inflow is now read.

General note:
If I understood correctly, the script only allows 1 inflow per grid point, so any additional one is moved downstream 1 grid cell. This functionality is still kept with the proposed fix. I guess it's not that important if we have 1 (or maybe a bit more in case of >2 inflows at same point) grid shifts. I was trying to think how the exact grid could be kept and allow over 1 inflows, but this most probably would require introduction of additional txt files, etc, which would need excessive testing and development time. Maybe for future we could try to include such an update?